### PR TITLE
fix: MCPサーバー初期化時のリグレッションを修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,9 @@ try {
   const config = await loadConfig();
   sayCoeiroink = new SayCoeiroink(config);
   
+  await sayCoeiroink.initialize();
+  await sayCoeiroink.buildDynamicConfig();
+  
   operatorManager = new OperatorManager();
   await operatorManager.initialize();
   
@@ -62,6 +65,9 @@ try {
   
   // フォールバック設定で初期化
   sayCoeiroink = new SayCoeiroink();
+  await sayCoeiroink.initialize();
+  await sayCoeiroink.buildDynamicConfig();
+  
   operatorManager = new OperatorManager();
   await operatorManager.initialize();
 }
@@ -321,7 +327,7 @@ server.registerTool("say", {
   
   try {
     // src/say/index.jsを直接呼び出し（enqueue処理で即座に戻る）
-    const result = await sayCoeiroink.synthesizeText(message, {
+    const result = await sayCoeiroink.synthesizeTextAsync(message, {
       voice: voice || null,
       rate: rate || undefined,
       streamMode: streamMode || false,


### PR DESCRIPTION
## Summary
- リファクタリング後にMCPサーバーの音声出力機能が動作しなくなった問題を修正
- MCPサーバー初期化時に必要な設定プロセスを復旧
- sayツールの非同期処理を適切に実装

## Changes
- `sayCoeiroink.initialize()`と`buildDynamicConfig()`の呼び出しを追加
- sayツールで`synthesizeTextAsync()`メソッドを使用するよう修正
- フォールバック初期化処理にも同様の修正を適用

## Test plan
- [x] MCPサーバーの初期化が正常に動作することを確認
- [x] sayツールが音声合成を正常に実行することを確認
- [x] operator_assignツールが正常に動作することを確認
- [x] 標準入力からのJSONリクエストによる直接テストで動作確認

## Root Cause
リファクタリング時にCLIとMCPサーバーの初期化プロセスに差異が生じ、MCPサーバーで必要な設定ファイルの準備処理が実行されていませんでした。

🤖 Generated with [Claude Code](https://claude.ai/code)