### PR TITLE
docs: v2.1.0設定オプション完全ドキュメント化と用語統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,18 @@ COEIRO OperatorはCOEIROINKと連携して動作する高品質音声オペレ�
 - **動的設定管理**: COEIROINKサーバーから音声フォントを自動検出
 - **セッション管理**: 複数セッション間でのオペレータ重複防止
 
-## ✨ 新機能ハイライト (v1.1.0)
+## ✨ 新機能ハイライト (v2.1.0)
 
-### 🎵 音声システム大幅刷新
-- **ストリーミング処理パイプライン**: リサンプリング → フィルタリング → ノイズ除去
-- **高品質リサンプリング**: node-libsamplerate (SRC_SINC_MEDIUM_QUALITY)
-- **デジタルフィルタリング**: 24kHz ローパスフィルター搭載
-- **分離サンプルレート**: 生成24kHz/再生48kHz で効率と品質を両立
+### 🔧 設定構造の大幅改善
+- **機能別設定構造**: connection, voice, audio による整理
+- **レイテンシモード**: ultra-low / balanced / quality の3段階プリセット
+- **音声head途切れ対策**: 詳細なパディング・クロスフェード制御
+- **分割モード統一**: 用語を`chunkMode`から`splitMode`に変更
 
-### 🌍 クロスプラットフォーム対応
-- Windows / macOS / Linux ネイティブ音声出力
-- 外部コマンド依存からの脱却
+### 🎵 音声品質の最適化
+- **動的バッファ調整**: 音声長とチャンク位置に応じた最適化
+- **先頭チャンク保護**: 最初のチャンクで途切れ防止処理をスキップ
+- **設定プリセット**: 用途別の最適化済み設定を提供
 
 ## インストール
 
@@ -94,9 +95,9 @@ operator-manager status
 say-coeiroink "こんにちは"
 say-coeiroink -r 150 "ゆっくり話します"
 
-# 新機能: 分割モード制御（v2.0.0+）
-say-coeiroink --chunk-mode none "長文を分割せずにスムーズに読み上げ"
-say-coeiroink --chunk-mode small "短いレスポンス"  # 低レイテンシ
+# 新機能: 分割モード制御（v2.1.0+）
+say-coeiroink --split-mode none "長文を分割せずにスムーズに読み上げ"
+say-coeiroink --split-mode small "短いレスポンス"  # 低レイテンシ
 say-coeiroink --buffer-size 2048 "高品質再生"      # バッファ制御
 
 # オペレータ管理
@@ -113,7 +114,7 @@ COEIRO Operatorは以下のMCPツールを提供します：
 - `operator_release` - オペレータ解放  
 - `operator_status` - 状況確認
 - `operator_available` - 利用可能一覧
-- `say` - 音声出力（ストリーミング再生・分割モード・バッファ制御対応）
+- `say` - 音声出力（ストリーミング再生・splitMode・バッファ制御対応）
 
 ## 📚 ドキュメント
 

--- a/docs/config-samples/README.md
+++ b/docs/config-samples/README.md
@@ -1,0 +1,36 @@
+# 設定ファイルサンプル
+
+このディレクトリには、COEIRO Operatorの様々な用途に応じた設定ファイルのサンプルが含まれています。
+
+## 使用方法
+
+1. 適切なサンプルファイルを選択
+2. `~/.coeiro-operator/coeiroink-config.json` にコピー
+3. 必要に応じて `voice_id` などを環境に合わせて調整
+
+## サンプル一覧
+
+### [ultra-low-latency.json](./ultra-low-latency.json)
+- **用途**: リアルタイム対話、チャットボット
+- **特徴**: 最低レイテンシ、音声head途切れ対策最優先
+- **設定**: `latencyMode: "ultra-low"`, `splitMode: "small"`
+
+### [balanced.json](./balanced.json)
+- **用途**: 一般的な用途、Webアプリケーション
+- **特徴**: レイテンシと音質のバランス
+- **設定**: `latencyMode: "balanced"`, `splitMode: "auto"`
+
+### [high-quality.json](./high-quality.json)
+- **用途**: 高品質録音、プレゼンテーション
+- **特徴**: 最高音質、ノイズ除去有効
+- **設定**: `latencyMode: "quality"`, `splitMode: "large"`
+
+## 設定のカスタマイズ
+
+詳細な設定オプションについては、[設定オプション詳細ガイド](../configuration-options.md) を参照してください。
+
+## 注意事項
+
+- `voice_id` は環境に応じて適切な値に変更してください
+- 高品質設定はCPU負荷が高くなる場合があります
+- レイテンシ設定は用途に応じて調整してください

--- a/docs/config-samples/balanced.json
+++ b/docs/config-samples/balanced.json
@@ -1,0 +1,24 @@
+{
+  "connection": {
+    "host": "localhost",
+    "port": "50032"
+  },
+  "voice": {
+    "default_voice_id": "292ea286-3d5f-f1cc-157c-66462a6a9d08",
+    "rate": 200
+  },
+  "audio": {
+    "latencyMode": "balanced",
+    "splitMode": "auto",
+    "processing": {
+      "synthesisRate": 24000,
+      "playbackRate": 48000,
+      "noiseReduction": false,
+      "lowpassFilter": false
+    },
+    "splitSettings": {
+      "mediumSize": 50,
+      "overlapRatio": 0.1
+    }
+  }
+}

--- a/docs/config-samples/high-quality.json
+++ b/docs/config-samples/high-quality.json
@@ -1,0 +1,41 @@
+{
+  "connection": {
+    "host": "localhost",
+    "port": "50032"
+  },
+  "voice": {
+    "default_voice_id": "292ea286-3d5f-f1cc-157c-66462a6a9d08",
+    "rate": 180
+  },
+  "audio": {
+    "latencyMode": "quality",
+    "splitMode": "large",
+    "processing": {
+      "synthesisRate": 44100,
+      "playbackRate": 44100,
+      "noiseReduction": true,
+      "lowpassFilter": true,
+      "lowpassCutoff": 20000
+    },
+    "splitSettings": {
+      "largeSize": 100,
+      "overlapRatio": 0.15
+    },
+    "bufferSettings": {
+      "highWaterMark": 512,
+      "lowWaterMark": 256,
+      "dynamicAdjustment": false
+    },
+    "paddingSettings": {
+      "enabled": true,
+      "prePhonemeLength": 0.02,
+      "postPhonemeLength": 0.02,
+      "firstChunkOnly": false
+    },
+    "crossfadeSettings": {
+      "enabled": true,
+      "skipFirstChunk": false,
+      "overlapSamples": 48
+    }
+  }
+}

--- a/docs/config-samples/ultra-low-latency.json
+++ b/docs/config-samples/ultra-low-latency.json
@@ -1,0 +1,20 @@
+{
+  "connection": {
+    "host": "localhost",
+    "port": "50032"
+  },
+  "voice": {
+    "default_voice_id": "292ea286-3d5f-f1cc-157c-66462a6a9d08",
+    "rate": 220
+  },
+  "audio": {
+    "latencyMode": "ultra-low",
+    "splitMode": "small",
+    "processing": {
+      "synthesisRate": 24000,
+      "playbackRate": 48000,
+      "noiseReduction": false,
+      "lowpassFilter": false
+    }
+  }
+}

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -1,0 +1,451 @@
+# COEIRO Operator 設定オプション
+
+COEIRO Operatorの音声合成システムは、詳細な設定によりパフォーマンスと音質を調整できます。設定は機能別に整理されており、用途に応じた最適化が可能です。
+
+## 設定ファイルの場所
+
+設定ファイルは以下の優先順位で読み込まれます：
+
+1. `~/.coeiro-operator/coeiroink-config.json` （推奨）
+2. `{作業ディレクトリ}/.coeiroink/coeiroink-config.json`
+3. `/tmp/coeiroink-mcp-shared/coeiroink-config.json`
+
+## 設定構造
+
+### 基本構造（v2.1.0+）
+
+```json
+{
+  "connection": {
+    "host": "localhost",
+    "port": "50032"
+  },
+  "voice": {
+    "default_voice_id": "voice-uuid-here",
+    "default_style_id": 0,
+    "rate": 200
+  },
+  "audio": {
+    "latencyMode": "balanced",
+    "splitMode": "auto",
+    "bufferSize": 1024,
+    "processing": { ... },
+    "splitSettings": { ... },
+    "bufferSettings": { ... },
+    "paddingSettings": { ... },
+    "crossfadeSettings": { ... }
+  }
+}
+```
+
+## 接続設定（Connection）
+
+COEIROINK音声合成サーバーへの接続を設定します。
+
+```json
+{
+  "connection": {
+    "host": "localhost",
+    "port": "50032"
+  }
+}
+```
+
+| 設定項目 | 型 | デフォルト | 説明 |
+|----------|----|-----------|----- |
+| `host` | string | `"localhost"` | COEIROINK サーバーのホスト名またはIPアドレス |
+| `port` | string | `"50032"` | COEIROINK サーバーのポート番号 |
+
+## 音声設定（Voice）
+
+デフォルトの音声とスピーチパラメータを設定します。
+
+```json
+{
+  "voice": {
+    "default_voice_id": "292ea286-3d5f-f1cc-157c-66462a6a9d08",
+    "default_style_id": 46,
+    "rate": 200
+  }
+}
+```
+
+| 設定項目 | 型 | デフォルト | 説明 |
+|----------|----|-----------|----- |
+| `default_voice_id` | string | - | デフォルトで使用する音声のUUID |
+| `default_style_id` | number | - | デフォルトで使用するスタイルID |
+| `rate` | number | `200` | 話速（WPM: Words Per Minute） |
+
+## 音声処理設定（Audio）
+
+音声合成と再生の詳細な制御を行います。
+
+### レイテンシモード
+
+```json
+{
+  "audio": {
+    "latencyMode": "ultra-low"
+  }
+}
+```
+
+| モード | 用途 | 特徴 |
+|--------|------|------|
+| `ultra-low` | リアルタイム対話 | 最低レイテンシ、音声head途切れ対策を最優先 |
+| `balanced` | 一般用途 | レイテンシと音質のバランス |
+| `quality` | 高音質録音 | 最高音質、レイテンシは二の次 |
+
+### 分割モード
+
+長いテキストを効率的に処理するための分割設定です。
+
+```json
+{
+  "audio": {
+    "splitMode": "auto"
+  }
+}
+```
+
+| モード | 分割サイズ | 用途 |
+|--------|------------|------|
+| `none` | 分割なし | 短いテキスト、一括処理 |
+| `small` | 30文字 | 低レイテンシ重視 |
+| `medium` | 50文字 | バランス型 |
+| `large` | 100文字 | 高品質重視 |
+| `auto` | 自動判定 | テキスト長に応じて最適化 |
+
+### 音声処理設定
+
+```json
+{
+  "audio": {
+    "processing": {
+      "synthesisRate": 24000,
+      "playbackRate": 48000,
+      "noiseReduction": false,
+      "lowpassFilter": false,
+      "lowpassCutoff": 24000
+    }
+  }
+}
+```
+
+| 設定項目 | 型 | デフォルト | 説明 |
+|----------|----|-----------|----- |
+| `synthesisRate` | number | `24000` | 音声合成時のサンプルレート（Hz） |
+| `playbackRate` | number | `48000` | 再生時のサンプルレート（Hz） |
+| `noiseReduction` | boolean | `false` | Echogardenによるノイズ除去 |
+| `lowpassFilter` | boolean | `false` | ローパスフィルターの有効化 |
+| `lowpassCutoff` | number | `24000` | ローパスフィルターのカットオフ周波数（Hz） |
+
+### 分割設定
+
+テキスト分割の詳細なパラメータを制御します。
+
+```json
+{
+  "audio": {
+    "splitSettings": {
+      "smallSize": 30,
+      "mediumSize": 50,
+      "largeSize": 100,
+      "overlapRatio": 0.1
+    }
+  }
+}
+```
+
+| 設定項目 | 型 | デフォルト | 説明 |
+|----------|----|-----------|----- |
+| `smallSize` | number | `30` | smallモード時の分割サイズ（文字数） |
+| `mediumSize` | number | `50` | mediumモード時の分割サイズ（文字数） |
+| `largeSize` | number | `100` | largeモード時の分割サイズ（文字数） |
+| `overlapRatio` | number | `0.1` | チャンク間のオーバーラップ比率（0.0-1.0） |
+
+### バッファ設定
+
+音声ストリーミングのバッファ制御を行います。
+
+```json
+{
+  "audio": {
+    "bufferSettings": {
+      "highWaterMark": 256,
+      "lowWaterMark": 128,
+      "dynamicAdjustment": true
+    }
+  }
+}
+```
+
+| 設定項目 | 型 | デフォルト | 説明 |
+|----------|----|-----------|----- |
+| `highWaterMark` | number | `256` | スピーカーバッファの上限（バイト） |
+| `lowWaterMark` | number | `128` | スピーカーバッファの下限（バイト） |
+| `dynamicAdjustment` | boolean | `true` | 音声長に応じた動的バッファサイズ調整 |
+
+### パディング設定
+
+音声の前後に無音を挿入し、途切れを防止します。
+
+```json
+{
+  "audio": {
+    "paddingSettings": {
+      "enabled": true,
+      "prePhonemeLength": 0.01,
+      "postPhonemeLength": 0.01,
+      "firstChunkOnly": true
+    }
+  }
+}
+```
+
+| 設定項目 | 型 | デフォルト | 説明 |
+|----------|----|-----------|----- |
+| `enabled` | boolean | `true` | パディングの有効化 |
+| `prePhonemeLength` | number | `0.01` | 音声前の無音時間（秒） |
+| `postPhonemeLength` | number | `0.01` | 音声後の無音時間（秒） |
+| `firstChunkOnly` | boolean | `true` | 最初のチャンクのみパディングを適用 |
+
+### クロスフェード設定
+
+チャンク間の滑らかな接続を実現します。
+
+```json
+{
+  "audio": {
+    "crossfadeSettings": {
+      "enabled": true,
+      "skipFirstChunk": true,
+      "overlapSamples": 24
+    }
+  }
+}
+```
+
+| 設定項目 | 型 | デフォルト | 説明 |
+|----------|----|-----------|----- |
+| `enabled` | boolean | `true` | クロスフェードの有効化 |
+| `skipFirstChunk` | boolean | `true` | 最初のチャンクでクロスフェードをスキップ |
+| `overlapSamples` | number | `24` | フェード処理を適用するサンプル数 |
+
+## レイテンシモード別プリセット
+
+### Ultra-Low レイテンシモード
+
+```json
+{
+  "audio": {
+    "latencyMode": "ultra-low",
+    "bufferSettings": {
+      "highWaterMark": 64,
+      "lowWaterMark": 32,
+      "dynamicAdjustment": true
+    },
+    "paddingSettings": {
+      "enabled": false,
+      "prePhonemeLength": 0,
+      "postPhonemeLength": 0,
+      "firstChunkOnly": true
+    },
+    "crossfadeSettings": {
+      "enabled": false,
+      "skipFirstChunk": true,
+      "overlapSamples": 0
+    }
+  }
+}
+```
+
+**特徴**: 音声head途切れ対策を最優先、最小レイテンシを実現
+
+### Balanced モード
+
+```json
+{
+  "audio": {
+    "latencyMode": "balanced",
+    "bufferSettings": {
+      "highWaterMark": 256,
+      "lowWaterMark": 128,
+      "dynamicAdjustment": true
+    },
+    "paddingSettings": {
+      "enabled": true,
+      "prePhonemeLength": 0.01,
+      "postPhonemeLength": 0.01,
+      "firstChunkOnly": true
+    },
+    "crossfadeSettings": {
+      "enabled": true,
+      "skipFirstChunk": true,
+      "overlapSamples": 24
+    }
+  }
+}
+```
+
+**特徴**: レイテンシと音質のバランス、一般的な用途に最適
+
+### Quality モード
+
+```json
+{
+  "audio": {
+    "latencyMode": "quality",
+    "bufferSettings": {
+      "highWaterMark": 512,
+      "lowWaterMark": 256,
+      "dynamicAdjustment": false
+    },
+    "paddingSettings": {
+      "enabled": true,
+      "prePhonemeLength": 0.02,
+      "postPhonemeLength": 0.02,
+      "firstChunkOnly": false
+    },
+    "crossfadeSettings": {
+      "enabled": true,
+      "skipFirstChunk": false,
+      "overlapSamples": 48
+    }
+  }
+}
+```
+
+**特徴**: 最高音質、録音や高品質再生に最適
+
+## 後方互換性
+
+v2.1.0以前の設定形式も引き続きサポートされます。新形式と併用する場合、新形式が優先されます。
+
+### 旧形式の例
+
+```json
+{
+  "host": "localhost",
+  "port": "50032",
+  "voice_id": "voice-uuid-here",
+  "style_id": 0,
+  "rate": 200,
+  "defaultChunkMode": "auto",
+  "defaultBufferSize": 1024,
+  "chunkSizeSmall": 30,
+  "chunkSizeMedium": 50,
+  "chunkSizeLarge": 100,
+  "overlapRatio": 0.1
+}
+```
+
+## 設定例
+
+### リアルタイム対話用設定
+
+```json
+{
+  "connection": {
+    "host": "localhost",
+    "port": "50032"
+  },
+  "voice": {
+    "default_voice_id": "your-voice-id",
+    "rate": 180
+  },
+  "audio": {
+    "latencyMode": "ultra-low",
+    "splitMode": "small"
+  }
+}
+```
+
+### 高品質録音用設定
+
+```json
+{
+  "connection": {
+    "host": "localhost",
+    "port": "50032"
+  },
+  "voice": {
+    "default_voice_id": "your-voice-id",
+    "rate": 200
+  },
+  "audio": {
+    "latencyMode": "quality",
+    "splitMode": "large",
+    "processing": {
+      "synthesisRate": 44100,
+      "playbackRate": 44100,
+      "noiseReduction": true,
+      "lowpassFilter": true
+    }
+  }
+}
+```
+
+### カスタム詳細設定
+
+```json
+{
+  "connection": {
+    "host": "localhost",
+    "port": "50032"
+  },
+  "voice": {
+    "default_voice_id": "your-voice-id",
+    "rate": 200
+  },
+  "audio": {
+    "latencyMode": "balanced",
+    "splitMode": "medium",
+    "bufferSettings": {
+      "highWaterMark": 512,
+      "lowWaterMark": 256,
+      "dynamicAdjustment": true
+    },
+    "paddingSettings": {
+      "enabled": true,
+      "prePhonemeLength": 0.015,
+      "postPhonemeLength": 0.015,
+      "firstChunkOnly": true
+    },
+    "crossfadeSettings": {
+      "enabled": true,
+      "skipFirstChunk": true,
+      "overlapSamples": 32
+    },
+    "splitSettings": {
+      "mediumSize": 60,
+      "overlapRatio": 0.15
+    }
+  }
+}
+```
+
+## トラブルシューティング
+
+### 音声が途切れる場合
+
+1. `latencyMode` を `"ultra-low"` に設定
+2. `crossfadeSettings.skipFirstChunk` を `true` に設定
+3. `paddingSettings.enabled` を `false` に設定
+
+### レイテンシが高い場合
+
+1. `bufferSettings.highWaterMark` を小さく設定（64-128）
+2. `splitMode` を `"small"` に変更
+3. `processing.noiseReduction` を `false` に設定
+
+### 音質を優先したい場合
+
+1. `latencyMode` を `"quality"` に設定
+2. `processing.synthesisRate` と `playbackRate` を高く設定
+3. `processing.noiseReduction` を `true` に設定
+
+## 参考資料
+
+- [音声ストリーミングシステムガイド](./audio-streaming-guide.md)
+- [開発Tips](./development-tips.md)


### PR DESCRIPTION
## Summary

v2.1.0に向けた設定オプションの完全ドキュメント化と用語統一を実施しました。

### 🆕 新規ドキュメント

- **`docs/configuration-options.md`**: 設定オプション詳細ガイド
  - 機能別設定構造（connection/voice/audio）の説明
  - レイテンシモード（ultra-low/balanced/quality）詳細
  - 全設定項目の一覧表と使用例
  - トラブルシューティング

- **`docs/config-samples/`**: 用途別設定ファイルサンプル
  - `ultra-low-latency.json`: リアルタイム対話用
  - `balanced.json`: 一般用途向け
  - `high-quality.json`: 高品質録音用

### 🔄 ドキュメント更新

- **`docs/audio-streaming-guide.md`**: 分割モード用語統一
  - `chunkMode` → `splitMode` 全面変更
  - 新設定構造への対応
  - v2.1.0機能の反映

- **`README.md`**: v2.1.0新機能ハイライト
  - 設定構造改善の説明
  - 音声品質最適化機能の紹介
  - コマンドライン例の用語統一

- **`CLAUDE.md`**: プロジェクト設定更新
  - 音声設定セクションの刷新
  - 新ドキュメントリンクの追加

### 🎯 主な改善点

1. **用語の一貫性**: `chunkMode` → `splitMode` で統一
2. **包括的な設定説明**: 全オプションの詳細解説
3. **用途別最適化**: 3つのレイテンシモード対応設定
4. **実践的なガイド**: トラブルシューティングと設定例

## Test plan

- [ ] 新しいドキュメントの内容確認
- [ ] 設定サンプルファイルの動作確認
- [ ] 用語統一の完全性チェック
- [ ] リンク切れの確認

🤖 Generated with [Claude Code](https://claude.ai/code)