### PR TITLE
fix: プロトタイプ汚染脆弱性の修正 #2

### DIFF
--- a/src/operator/config-manager.ts
+++ b/src/operator/config-manager.ts
@@ -135,12 +135,25 @@ export class ConfigManager {
     }
 
     /**
-     * 再帰的なオブジェクトマージ
+     * 再帰的なオブジェクトマージ（プロトタイプ汚染対策済み）
      */
     deepMerge(target: any, source: any): any {
         const result = { ...target };
         
+        // プロトタイプ汚染防止のための危険なキーリスト
+        const dangerousKeys = ['__proto__', 'constructor', 'prototype'];
+        
         for (const key in source) {
+            // 危険なキーをスキップ
+            if (dangerousKeys.includes(key)) {
+                continue;
+            }
+            
+            // hasOwnPropertyチェックで継承されたプロパティを除外
+            if (!Object.prototype.hasOwnProperty.call(source, key)) {
+                continue;
+            }
+            
             if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
                 result[key] = this.deepMerge(result[key] || {}, source[key]);
             } else {


### PR DESCRIPTION
## 概要

Issue #2で報告されたプロトタイプ汚染脆弱性を修正し、包括的なセキュリティテストを追加しました。

## 修正内容

### セキュリティ修正
- **ファイル**: `src/operator/config-manager.ts:140-165`
- **メソッド**: `deepMerge`
- **対策**: 危険なキー (`__proto__`, `constructor`, `prototype`) のフィルタリング
- **強化**: `Object.prototype.hasOwnProperty.call()` による継承プロパティの除外

### セキュリティテストの追加
- **ファイル**: `src/operator/config-manager.test.ts:125-172`
- **テスト種類**: 
  - `__proto__` 汚染攻撃の防御テスト
  - `constructor` 汚染攻撃の防御テスト
  - `prototype` 汚染攻撃の防御テスト
  - 継承プロパティ除外の検証テスト

## テスト結果

```
✓ プロトタイプ汚染攻撃を防ぐ - __proto__
✓ プロトタイプ汚染攻撃を防ぐ - constructor
✓ プロトタイプ汚染攻撃を防ぐ - prototype
✓ 継承されたプロパティは無視される
```

全てのセキュリティテストが成功し、設定ファイルの安全なマージが保証されています。

## セキュリティ影響

- **修正前**: 設定ファイルマージ時にプロトタイプ汚染の可能性
- **修正後**: プロトタイプチェーン汚染を完全に防止
- **リスクレベル**: 高 → 解決済み

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)