### PR TITLE
fix: Speakerインスタンス使い回し実装で音声出力停止問題を解決

### DIFF
--- a/src/core/say/index.ts
+++ b/src/core/say/index.ts
@@ -535,6 +535,28 @@ export class SayCoeiroink {
     getStreamControllerOptions() {
         return this.audioSynthesizer.getStreamControllerOptions();
     }
+
+    /**
+     * SayCoeiroinkインスタンスのクリーンアップ（リソース解放）
+     * 長時間運用やシャットダウン時に呼び出し
+     */
+    async cleanup(): Promise<void> {
+        logger.debug('SayCoeiroink cleanup開始');
+        
+        try {
+            // SpeechQueueのクリア
+            this.speechQueue.clear();
+            
+            // AudioPlayerのクリーンアップ
+            await this.audioPlayer.cleanup();
+            
+            // AudioSynthesizerには特別なクリーンアップは不要（HTTPクライアントベース）
+            
+            logger.info('SayCoeiroink cleanup完了');
+        } catch (error) {
+            logger.warn(`SayCoeiroink cleanup warning: ${(error as Error).message}`);
+        }
+    }
 }
 
 // デフォルトエクスポート


### PR DESCRIPTION
## 問題の概要

MCPモードでの断続的な音声出力において、時間が経過すると音声が出なくなる問題を修正しました。

## 🔍 根本原因

- **毎回新規作成**: `playPCMData`メソッド内で毎回新しいSpeakerインスタンスを作成
- **二重管理**: 初期化時のSpeakerインスタンスが未使用状態
- **リソースリーク**: 長時間運用でのSpeakerインスタンス蓄積が音声出力停止の原因

## ✨ 修正内容

### AudioPlayer クラスの改善
- `currentSpeakerConfig` フィールドでSpeaker設定を追跡
- `getOrCreateSpeaker()` メソッドで設定ベースの使い回し実装
- `cleanupCurrentSpeaker()` メソッドで適切なリソース解放
- `cleanup()` メソッドで完全なクリーンアップ機能

### 技術的改善点
- サンプルレート、チャンネル、ビット深度、バッファサイズが同じ場合は既存インスタンス使い回し
- COEIROINK固定設定（24kHz→48kHz）では実質的に1つのインスタンス使い回し
- `speaker.destroy()` による適切なリソース解放

## 📈 期待される効果

- **リソースリーク解消**: 長時間運用での音声出力停止問題を解決
- **パフォーマンス向上**: 音声出力初期化オーバーヘッドの削減
- **安定性向上**: メモリ使用量の安定化

## 🧪 テスト結果

連続的なMCP sayコマンドでの動作確認を実施し、正常な音声出力を確認済み。

🤖 Generated with [Claude Code](https://claude.ai/code)