### PR TITLE
fix: getOtherEntriesがnullを返す場合のエラーを修正

### DIFF
--- a/src/core/operator/index.ts
+++ b/src/core/operator/index.ts
@@ -193,7 +193,7 @@ export class OperatorManager {
 
         const allOperators = await this.configManager.getAvailableCharacterIds();
         const otherAssignments = await this.dataStore.getOtherEntries();
-        const busyOperators = Object.values(otherAssignments);
+        const busyOperators = otherAssignments ? Object.values(otherAssignments) : [];
         
         const availableOperators = allOperators.filter(op => !busyOperators.includes(op));
         


### PR DESCRIPTION
## 概要
MCPツールで `operator_status` や `operator_available` を実行した際に発生するエラーを修正しました。

## エラー内容
```
Error: オペレータ状況確認エラー: Cannot convert undefined or null to object
```

## 原因
`getAvailableOperators` メソッド内で、`dataStore.getOtherEntries()` が `null` または `undefined` を返す場合に、`Object.values()` でエラーが発生していました。

## 修正内容
`otherAssignments` が `null` または `undefined` の場合は空配列を使用するように修正：

```typescript
// Before
const busyOperators = Object.values(otherAssignments);

// After  
const busyOperators = otherAssignments ? Object.values(otherAssignments) : [];
```

## テスト結果
- ✅ `operator_status` が正常に動作
- ✅ `operator_available` が正常に動作
- ✅ ビルドエラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)