### PR TITLE
fix: ES modules環境でのuv検出エラーを修正

### DIFF
--- a/packages/term-bg/src/index.ts
+++ b/packages/term-bg/src/index.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { spawn, execSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import { getDirname } from '@coeiro-operator/common';
@@ -227,7 +227,6 @@ export class TerminalBackground {
    */
   private isUvAvailable(): boolean {
     try {
-      const { execSync } = require('child_process');
       execSync('which uv', { stdio: 'ignore' });
       return true;
     } catch {


### PR DESCRIPTION
## 概要
ES modules環境で`require`を使用していたため、uvの検出が失敗していた問題を修正しました。

## 問題
```
ERROR ❌ 背景画像の設定に失敗: Error: uv is not available
```
- `isUvAvailable()`メソッドでCommonJSの`require`を使用していた
- ES modules環境では`require`が使えないため、uvの検出が常に失敗

## 修正内容
- `execSync`を直接importするように変更
- ES modulesの正しいインポート方法に統一

## テスト
- ビルドが正常に完了することを確認
- operator-manager assignでuvが正しく検出されることを確認予定

🤖 Generated with Claude Code