### PR TITLE
fix: operator-manager releaseコマンドをエラーをスローしない仕様に変更

### DIFF
--- a/packages/cli/src/operator-manager.ts
+++ b/packages/cli/src/operator-manager.ts
@@ -20,7 +20,10 @@ interface AssignResult {
 }
 
 interface ReleaseResult {
-  characterName: string;
+  characterId?: string;
+  characterName?: string;
+  farewell?: string;
+  wasAssigned: boolean;
 }
 
 interface StatusResult {
@@ -149,9 +152,14 @@ class OperatorManagerCLI {
 
   async handleRelease(): Promise<void> {
     const result: ReleaseResult = await this.manager.releaseOperator();
-    console.log(`オペレータ返却: ${result.characterName}`);
 
-    // 背景画像をクリア
+    if (result.wasAssigned) {
+      console.log(`オペレータ返却: ${result.characterName}`);
+    } else {
+      console.log('オペレータは割り当てられていません');
+    }
+
+    // 背景画像をクリア（オペレータの有無に関わらず実行）
     if (this.terminalBackground && await this.terminalBackground.isEnabled()) {
       await this.terminalBackground.clearBackground();
     }

--- a/packages/core/src/operator/index.ts
+++ b/packages/core/src/operator/index.ts
@@ -40,9 +40,10 @@ interface AssignResult {
 }
 
 interface ReleaseResult {
-  characterId: string; // キャラクターID
-  characterName: string; // キャラクター表示名
-  farewell: string;
+  characterId?: string; // キャラクターID（未割り当ての場合はundefined）
+  characterName?: string; // キャラクター表示名（未割り当ての場合はundefined）
+  farewell?: string; // お別れメッセージ（未割り当ての場合はundefined）
+  wasAssigned: boolean; // オペレータが割り当てられていたかどうか
 }
 
 interface StatusResult {
@@ -199,12 +200,16 @@ export class OperatorManager {
 
   /**
    * オペレータを返却
+   * オペレータが割り当てられていない場合も正常として扱う（時間切れ自動解放のケースがあるため）
    */
   async releaseOperator(): Promise<ReleaseResult> {
     const operatorSession = await this.getCurrentOperatorSession();
 
     if (!operatorSession) {
-      throw new Error('このセッションにはオペレータが割り当てられていません');
+      // オペレータが割り当てられていない場合も正常として扱う
+      return {
+        wasAssigned: false,
+      };
     }
 
     const characterId = operatorSession.characterId;
@@ -226,6 +231,7 @@ export class OperatorManager {
       characterId,
       characterName: character?.speaker?.speakerName || characterId,
       farewell: character?.farewell || '',
+      wasAssigned: true,
     };
   }
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -365,9 +365,18 @@ server.registerTool(
   },
   async (): Promise<ToolResponse> => {
     try {
-      await operatorManager.releaseOperator();
+      const result = await operatorManager.releaseOperator();
 
-      // 背景画像をクリア
+      let releaseMessage: string;
+      if (result.wasAssigned) {
+        releaseMessage = `オペレータを解放しました: ${result.characterName}`;
+        logger.info(`オペレータ解放: ${result.characterId}`);
+      } else {
+        releaseMessage = 'オペレータは割り当てられていません';
+        logger.info('オペレータ未割り当て状態');
+      }
+
+      // 背景画像をクリア（オペレータの有無に関わらず実行）
       if (terminalBackground) {
         if (await terminalBackground.isEnabled()) {
           await terminalBackground.clearBackground();
@@ -379,7 +388,7 @@ server.registerTool(
         content: [
           {
             type: 'text',
-            text: 'オペレータを解放しました',
+            text: releaseMessage,
           },
         ],
       };


### PR DESCRIPTION
## 概要
`operator-manager release`コマンドがオペレータ未割り当て時にエラーをスローせず、正常な状態として扱うように変更しました。

## 変更内容
- ✅ `releaseOperator`メソッドがオペレータ未割り当て時にエラーをスローしない仕様に変更
- ✅ `ReleaseResult`型に`wasAssigned`フラグを追加して割り当て状態を返すように修正
- ✅ オペレータの有無に関わらず背景画像クリアが実行されるように改善

## 背景
時間切れによる自動解放機能により「気づいたら帰っていた」というケースが発生するため、オペレータ未割り当ては異常系ではなく正常な状態として扱うべきです。

## テスト結果
```bash
# オペレータ割り当て時のリリース
$ operator-manager release
オペレータ返却: クロワちゃん
背景画像をクリアしました (Session: xxx)

# オペレータ未割り当て時のリリース（エラーにならない）
$ operator-manager release
オペレータは割り当てられていません
背景画像をクリアしました (Session: xxx)
```

## 影響範囲
- `packages/core/src/operator/index.ts`: releaseOperatorメソッドの仕様変更
- `packages/cli/src/operator-manager.ts`: CLIコマンドの処理を更新
- `packages/mcp/src/server.ts`: MCPサーバーの処理を更新

🤖 Generated with Claude Code