### PR TITLE
fix: リリースワークフローを保護されたmainブランチに対応

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,11 +8,5 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
-  "privatePackages": {
-    "version": true,
-    "tag": true
-  },
-  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "onlyUpdatePeerDependentsWhenOutOfRange": true
-  }
+  "privatePackages": false
 }

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Use default GITHUB_TOKEN, don't need to push to protected branch
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
@@ -51,23 +52,19 @@ jobs:
       - name: Build packages
         run: npm run build:all
 
-      - name: Version packages
-        run: |
-          npm run changeset:version
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "chore: version packages [skip ci]" || echo "No changes to commit"
-
       - name: Publish to npm
-        run: npm run changeset:publish
+        run: |
+          # Versions and changelogs are already updated in the release branch
+          # Just publish without version update
+          npm run changeset:publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Push version tags
+      - name: Push tags only
         run: |
-          git push --follow-tags
+          # Only push tags, not commits to main
+          git push origin --tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -101,11 +98,15 @@ jobs:
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -121,6 +122,22 @@ jobs:
       - name: Get branch name
         id: branch
         run: echo "name=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+
+      - name: Apply version updates
+        run: |
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Run changeset version to update versions and changelogs
+          npm run changeset:version
+
+          # Commit if there are changes
+          if [[ -n $(git status --porcelain) ]]; then
+            git add -A
+            git commit -m "chore: version packages for release"
+            git push origin HEAD
+          fi
 
       - name: Version preview
         run: |


### PR DESCRIPTION
## 問題

mainブランチが保護されているため、リリース時にバージョン更新のコミットをpushできません。

## 解決策

リリースブランチでバージョン更新を事前に行うように変更：

1. **release/*ブランチ作成時**
   - 自動で`changeset:version`を実行
   - package.jsonとCHANGELOGを更新
   - リリースブランチにコミット

2. **mainへマージ時**
   - すでに更新済みのバージョンでnpm publish
   - タグのみpush（コミットはしない）
   - mainへの直接変更を回避

## 変更内容

- `.github/workflows/release-branch.yml`を修正
  - リリースPR作成時にバージョン更新を実行
  - マージ時は公開のみ実行
- `.changeset/config.json`の不要な設定を削除

これにより、保護されたmainブランチでも正常にリリースできるようになります。