### PR TITLE
fix: ルートパッケージを非公開にしてインストール手順を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,21 @@ COEIRO OperatorはCOEIROINKの音声合成を活用し、端末セッション�
 
 ### 1. インストール
 
-```bash
-# NPMからのインストール
-npm install -g coeiro-operator
+#### CLIツール
 
-# MCPサーバー登録（Claude Code）
-claude mcp add -s user coeiro-operator
+```bash
+# CLIツールのインストール
+npm install -g @coeiro-operator/cli
+```
+
+#### MCPサーバー（Claude Code用）
+
+```bash
+# MCPサーバーのインストール
+npm install -g @coeiro-operator/mcp
+
+# MCPサーバー登録
+claude mcp add @coeiro-operator/mcp
 
 # AI Agent用の設定（Claude Code利用時）
 # 音声対話が必要な場合、prompts/recipes/operator-mode.mdを

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "MCP server for COEIROINK voice synthesis and operator management",
   "type": "module",
+  "private": true,
   "workspaces": [
     "packages/*"
   ],

--- a/packages/cli/src/dictionary-register.ts
+++ b/packages/cli/src/dictionary-register.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 
 /**
  * COEIROINK ユーザー辞書登録 CLIツール

--- a/packages/cli/src/operator-manager.ts
+++ b/packages/cli/src/operator-manager.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 
 /**
  * src/operator/cli.ts: オペレータ管理CLI

--- a/packages/cli/src/say-coeiroink.ts
+++ b/packages/cli/src/say-coeiroink.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 
 /**
  * src/say/cli.ts: say-coeiroinkコマンドラインインターフェース

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';


### PR DESCRIPTION
## 概要

ルートパッケージ `coeiro-operator` を非公開にし、各パッケージを個別にインストールする構成に変更しました。

## 背景

現在の構成では、`npm install -g coeiro-operator` でインストールしても動作しません：
- `scripts/` のシェルスクリプトは公開される
- しかし `packages/*/dist/` は公開されない
- スクリプトが参照するファイルが存在しない

## 変更内容

### 1. ルートパッケージを非公開に
```json
{
  "private": true
}
```

### 2. インストール手順を更新

**Before:**
```bash
npm install -g coeiro-operator
```

**After:**
```bash
# CLIツール
npm install -g @coeiro-operator/cli

# MCPサーバー
npm install -g @coeiro-operator/mcp
```

### 3. Warning抑制を追加

すべてのbinスクリプトのshebangに `--no-deprecation` を追加：
- packages/cli/src/*.ts
- packages/mcp/src/server.ts

## メリット

- 明確で一貫性のあるパッケージ構成
- 各パッケージが独立して動作
- 必要なものだけインストール可能
- punycode等の非推奨警告が表示されない