### PR TITLE
Release v1.0.1 (with version update)

### DIFF
--- a/.changeset/changeset-285c01.md
+++ b/.changeset/changeset-285c01.md
@@ -1,9 +1,0 @@
----
-"@coeiro-operator/cli": patch
-"@coeiro-operator/mcp": patch
-"@coeiro-operator/audio": patch
-"@coeiro-operator/common": patch
-"@coeiro-operator/core": patch
----
-
-Add README documentation for all packages and update MCP usage examples

--- a/.changeset/changeset-3c96eb.md
+++ b/.changeset/changeset-3c96eb.md
@@ -1,6 +1,0 @@
----
-"@coeiro-operator/cli": patch
-"@coeiro-operator/mcp": patch
----
-
-Fix deprecation warnings by adding --no-deprecation flag to all bin scripts

--- a/packages/audio/CHANGELOG.md
+++ b/packages/audio/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @coeiro-operator/audio
+
+## 1.0.1
+
+### Patch Changes
+
+- f596a2d: Add README documentation for all packages and update MCP usage examples
+- Updated dependencies [f596a2d]
+  - @coeiro-operator/common@1.0.1
+  - @coeiro-operator/core@1.0.1

--- a/packages/audio/package.json
+++ b/packages/audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coeiro-operator/audio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Audio synthesis and playback module for COEIRO Operator",
   "type": "module",
   "main": "dist/index.js",
@@ -24,8 +24,8 @@
     "format": "prettier --write \"src/**/*.{ts,js,json,md}\""
   },
   "dependencies": {
-    "@coeiro-operator/common": "^1.0.0",
-    "@coeiro-operator/core": "^1.0.0",
+    "@coeiro-operator/common": "^1.0.1",
+    "@coeiro-operator/core": "^1.0.1",
     "dsp.js": "^1.0.1",
     "echogarden": "^2.10.1",
     "node-fetch": "^3.3.2",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @coeiro-operator/cli
+
+## 1.0.1
+
+### Patch Changes
+
+- f596a2d: Add README documentation for all packages and update MCP usage examples
+- db96813: Fix deprecation warnings by adding --no-deprecation flag to all bin scripts
+- Updated dependencies [f596a2d]
+  - @coeiro-operator/audio@1.0.1
+  - @coeiro-operator/common@1.0.1
+  - @coeiro-operator/core@1.0.1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coeiro-operator/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI tools for COEIRO Operator",
   "type": "module",
   "main": "dist/index.js",
@@ -29,9 +29,9 @@
     "format": "prettier --write \"src/**/*.{ts,js,json,md}\""
   },
   "dependencies": {
-    "@coeiro-operator/audio": "^1.0.0",
-    "@coeiro-operator/common": "^1.0.0",
-    "@coeiro-operator/core": "^1.0.0",
+    "@coeiro-operator/audio": "^1.0.1",
+    "@coeiro-operator/common": "^1.0.1",
+    "@coeiro-operator/core": "^1.0.1",
     "commander": "^14.0.1"
   },
   "devDependencies": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @coeiro-operator/common
+
+## 1.0.1
+
+### Patch Changes
+
+- f596a2d: Add README documentation for all packages and update MCP usage examples

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coeiro-operator/common",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Common utilities and logger for COEIRO Operator",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @coeiro-operator/core
+
+## 1.0.1
+
+### Patch Changes
+
+- f596a2d: Add README documentation for all packages and update MCP usage examples
+- Updated dependencies [f596a2d]
+  - @coeiro-operator/common@1.0.1

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coeiro-operator/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Core utilities and shared functionality for COEIRO Operator",
   "type": "module",
   "main": "dist/index.js",
@@ -24,7 +24,7 @@
     "format": "prettier --write \"src/**/*.{ts,js,json,md}\""
   },
   "dependencies": {
-    "@coeiro-operator/common": "^1.0.0",
+    "@coeiro-operator/common": "^1.0.1",
     "@coeiro-operator/term-bg": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @coeiro-operator/mcp
+
+## 1.0.1
+
+### Patch Changes
+
+- f596a2d: Add README documentation for all packages and update MCP usage examples
+- db96813: Fix deprecation warnings by adding --no-deprecation flag to all bin scripts
+- Updated dependencies [f596a2d]
+  - @coeiro-operator/audio@1.0.1
+  - @coeiro-operator/common@1.0.1
+  - @coeiro-operator/core@1.0.1

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coeiro-operator/mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP server for COEIRO Operator",
   "type": "module",
   "main": "dist/server.js",
@@ -28,9 +28,9 @@
     "format": "prettier --write \"src/**/*.{ts,js,json,md}\""
   },
   "dependencies": {
-    "@coeiro-operator/common": "^1.0.0",
-    "@coeiro-operator/core": "^1.0.0",
-    "@coeiro-operator/audio": "^1.0.0",
+    "@coeiro-operator/common": "^1.0.1",
+    "@coeiro-operator/core": "^1.0.1",
+    "@coeiro-operator/audio": "^1.0.1",
     "@modelcontextprotocol/sdk": "^1.17.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🚀 Release v1.0.1

### Changes
- Add README documentation for all packages
- Update MCP usage examples  
- Fix deprecation warnings in bin scripts
- Make root package private

### Packages to be updated (patch)
- @coeiro-operator/cli (1.0.0 → 1.0.1)
- @coeiro-operator/mcp (1.0.0 → 1.0.1)
- @coeiro-operator/audio (1.0.0 → 1.0.1)
- @coeiro-operator/common (1.0.0 → 1.0.1)
- @coeiro-operator/core (1.0.0 → 1.0.1)

### Note
Previous PR #112 was merged but published as 1.0.0 because version update was not applied. This PR includes the actual version update to 1.0.1.

---
⚠️ **Merging this PR will automatically publish to npm**