### PR TITLE
Release @coeiro-operator/mcp v1.0.2

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @coeiro-operator/mcp
 
+## 1.0.2
+
+### Patch Changes
+
+- npm レジストリで破損した 1.0.1 パッケージを修正
+  - 1.0.1 のパブリッシュ時に発生した integrity checksum エラーを修正
+  - pnpm 移行により今後の並列パブリッシュ問題を防止
+  - パッケージの再パブリッシュにより正常なバージョンを提供
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coeiro-operator/mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP server for COEIRO Operator",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## 🚀 Release

### @coeiro-operator/mcp v1.0.2

npm レジストリで破損した 1.0.1 パッケージを修正するためのパッチリリース

#### 修正内容
- 1.0.1 のパブリッシュ時に発生した integrity checksum エラーを修正
- pnpm 移行により今後の並列パブリッシュ問題を防止
- パッケージの再パブリッシュにより正常なバージョンを提供

⚠️ **Merging this PR will automatically publish to npm**

### 影響範囲
- @coeiro-operator/mcp のみ (1.0.1 → 1.0.2)
- 他のパッケージは影響なし

### テスト
- ✅ pnpm build 成功
- ✅ pnpm test 成功
- ✅ CI すべてpass

🤖 Generated with Claude Code