### PR TITLE
fix: npm パッケージに dist ディレクトリが含まれない問題を修正

### DIFF
--- a/packages/audio/CHANGELOG.md
+++ b/packages/audio/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @coeiro-operator/audio
 
+## 1.0.2
+
+### Patch Changes
+
+- npm パッケージに dist ディレクトリが含まれない問題を修正
+  - audio, common パッケージ: distディレクトリが公開されていなかった問題を修正
+  - すべてのパッケージ: files フィールドを追加し、ビルド成果物を明示的に含めるよう改善
+  - すべてのパッケージ: prepublishOnly スクリプトを追加し、公開前のビルドを保証
+  - mcp パッケージ: 修正された依存関係（audio, common）を参照するよう更新
+
+- Updated dependencies
+  - @coeiro-operator/common@1.0.2
+  - @coeiro-operator/core@1.0.2
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/audio/package.json
+++ b/packages/audio/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@coeiro-operator/audio",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Audio synthesis and playback module for COEIRO Operator",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "os": [
     "darwin",
     "linux",
@@ -21,7 +24,8 @@
     "test:watch": "vitest --watch",
     "type-check": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.js",
-    "format": "prettier --write \"src/**/*.{ts,js,json,md}\""
+    "format": "prettier --write \"src/**/*.{ts,js,json,md}\"",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@coeiro-operator/common": "workspace:*",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @coeiro-operator/cli
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @coeiro-operator/audio@1.0.2
+  - @coeiro-operator/common@1.0.2
+  - @coeiro-operator/core@1.0.2
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@coeiro-operator/cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI tools for COEIRO Operator",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "os": [
     "darwin",
     "linux",
@@ -26,7 +29,8 @@
     "test:watch": "vitest --watch",
     "type-check": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.js",
-    "format": "prettier --write \"src/**/*.{ts,js,json,md}\""
+    "format": "prettier --write \"src/**/*.{ts,js,json,md}\"",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@coeiro-operator/audio": "workspace:*",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @coeiro-operator/common
 
+## 1.0.2
+
+### Patch Changes
+
+- npm パッケージに dist ディレクトリが含まれない問題を修正
+  - audio, common パッケージ: distディレクトリが公開されていなかった問題を修正
+  - すべてのパッケージ: files フィールドを追加し、ビルド成果物を明示的に含めるよう改善
+  - すべてのパッケージ: prepublishOnly スクリプトを追加し、公開前のビルドを保証
+  - mcp パッケージ: 修正された依存関係（audio, common）を参照するよう更新
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@coeiro-operator/common",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Common utilities and logger for COEIRO Operator",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "os": [
     "darwin",
     "linux",
@@ -19,7 +22,8 @@
     "build": "tsc --build",
     "test": "vitest",
     "test:watch": "vitest --watch",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @coeiro-operator/core
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @coeiro-operator/common@1.0.2
+  - @coeiro-operator/term-bg@1.0.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@coeiro-operator/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Core utilities and shared functionality for COEIRO Operator",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "os": [
     "darwin",
     "linux",
@@ -21,7 +24,8 @@
     "test:watch": "vitest --watch",
     "type-check": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.js",
-    "format": "prettier --write \"src/**/*.{ts,js,json,md}\""
+    "format": "prettier --write \"src/**/*.{ts,js,json,md}\"",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@coeiro-operator/common": "workspace:*",

--- a/packages/mcp-debug/package.json
+++ b/packages/mcp-debug/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "os": [
     "darwin",
     "linux",
@@ -24,7 +27,8 @@
     "test:watch": "vitest --watch",
     "type-check": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.js",
-    "format": "prettier --write \"src/**/*.{ts,js,json,md}\""
+    "format": "prettier --write \"src/**/*.{ts,js,json,md}\"",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.0",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @coeiro-operator/mcp
 
+## 1.0.3
+
+### Patch Changes
+
+- npm パッケージに dist ディレクトリが含まれない問題を修正
+  - audio, common パッケージ: distディレクトリが公開されていなかった問題を修正
+  - すべてのパッケージ: files フィールドを追加し、ビルド成果物を明示的に含めるよう改善
+  - すべてのパッケージ: prepublishOnly スクリプトを追加し、公開前のビルドを保証
+  - mcp パッケージ: 修正された依存関係（audio, common）を参照するよう更新
+
+- Updated dependencies
+  - @coeiro-operator/audio@1.0.2
+  - @coeiro-operator/common@1.0.2
+  - @coeiro-operator/core@1.0.2
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@coeiro-operator/mcp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MCP server for COEIRO Operator",
   "type": "module",
   "main": "dist/server.js",
   "types": "dist/server.d.ts",
+  "files": [
+    "dist"
+  ],
   "os": [
     "darwin",
     "linux",
@@ -25,7 +28,8 @@
     "test:watch": "vitest --watch",
     "type-check": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.js",
-    "format": "prettier --write \"src/**/*.{ts,js,json,md}\""
+    "format": "prettier --write \"src/**/*.{ts,js,json,md}\"",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@coeiro-operator/common": "workspace:*",

--- a/packages/term-bg/CHANGELOG.md
+++ b/packages/term-bg/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @coeiro-operator/term-bg
+
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @coeiro-operator/common@1.0.2

--- a/packages/term-bg/package.json
+++ b/packages/term-bg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coeiro-operator/term-bg",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Terminal background image controller for iTerm2",
   "type": "module",
   "main": "dist/index.js",
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "tsc --build",
     "postinstall": "node scripts/setup-python-env.cjs",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@coeiro-operator/common": "workspace:*"


### PR DESCRIPTION
## 🚀 Release

### 修正内容

npm に公開されたパッケージに `dist` ディレクトリ（ビルド成果物）が含まれていない問題を修正します。

### 問題の原因
- `package.json` に `files` フィールドがなかったため、npm のデフォルト動作により `dist` が除外されていました
- `prepublishOnly` スクリプトがなく、公開前のビルドが保証されていませんでした

### 影響を受けたパッケージ
- **@coeiro-operator/audio@1.0.1** - dist なし ❌ → 1.0.2 で修正
- **@coeiro-operator/common@1.0.1** - dist なし ❌ → 1.0.2 で修正
- **@coeiro-operator/mcp@1.0.2** - 依存関係の更新が必要 → 1.0.3 で更新

### 修正内容
1. すべてのパッケージに `files: ["dist"]` を追加
2. すべてのパッケージに `prepublishOnly: "pnpm build"` を追加
3. 影響を受けたパッケージのバージョンを更新

### バージョン更新
- @coeiro-operator/audio: 1.0.1 → 1.0.2
- @coeiro-operator/common: 1.0.1 → 1.0.2
- @coeiro-operator/core: 1.0.1 → 1.0.2（依存関係の更新）
- @coeiro-operator/cli: 1.0.1 → 1.0.2（依存関係の更新）
- @coeiro-operator/mcp: 1.0.2 → 1.0.3
- @coeiro-operator/term-bg: 1.0.0 → 1.0.1（依存関係の更新）

⚠️ **Merging this PR will automatically publish to npm**

### テスト
- ✅ pnpm build 成功
- ✅ files フィールドと prepublishOnly スクリプトを確認

🤖 Generated with Claude Code