### PR TITLE
feat: タスクID指定でのキュー削除機能を追加

### DIFF
--- a/packages/audio/src/index.ts
+++ b/packages/audio/src/index.ts
@@ -154,12 +154,14 @@ export class SayCoeiroink {
 
   /**
    * キューをクリア
+   * @param taskIds 削除するタスクIDの配列（省略時は全タスク削除）
+   * @returns 削除されたタスク数
    */
-  clearSpeechQueue(): void {
+  clearSpeechQueue(taskIds?: number[]): { removedCount: number } {
     if (!this.speechQueue) {
       throw new Error('SpeechQueue is not initialized. Call initialize() first.');
     }
-    this.speechQueue.clear();
+    return this.speechQueue.clear(taskIds);
   }
 
   // ========================================================================
@@ -220,7 +222,7 @@ export class SayCoeiroink {
 
     try {
       if (this.speechQueue) {
-        this.speechQueue.clear();
+        this.speechQueue.clear(); // 全タスククリア
       }
 
       if (this.audioPlayer) {

--- a/packages/audio/src/speech-queue.ts
+++ b/packages/audio/src/speech-queue.ts
@@ -158,9 +158,30 @@ export class SpeechQueue {
 
   /**
    * キューをクリア
+   * @param taskIds 削除するタスクIDの配列（省略時は全タスク削除）
+   * @returns 削除されたタスク数
    */
-  clear(): void {
-    this.speechQueue = [];
-    this.isProcessing = false;
+  clear(taskIds?: number[]): { removedCount: number } {
+    if (!taskIds || taskIds.length === 0) {
+      // 既存の動作：全タスククリア
+      const count = this.speechQueue.length;
+      this.speechQueue = [];
+      this.isProcessing = false;
+      return { removedCount: count };
+    }
+
+    // 新機能：指定タスクのみ削除
+    const before = this.speechQueue.length;
+    this.speechQueue = this.speechQueue.filter(
+      task => !taskIds.includes(task.id)
+    );
+    const removedCount = before - this.speechQueue.length;
+
+    // キューが空になった場合は処理中フラグもリセット
+    if (this.speechQueue.length === 0) {
+      this.isProcessing = false;
+    }
+
+    return { removedCount };
   }
 }


### PR DESCRIPTION
## 概要
Issue #135 Phase 2の実装として、音声キューから特定のタスクIDを指定して削除する機能を追加しました。

## 背景
- Phase 1で実装済み: queue_status, queue_clear（全削除）, sayの返り値改善
- ユーザー要望: 「タスクIDのキャンセルもあって良いかもね。clearの引数にいれるのが簡単かな」

## 実装内容

### 🔧 主な変更点

1. **SpeechQueueクラス**
   - `clear(taskIds?: number[])` - タスクID指定削除に対応
   - 後方互換性維持（引数なしで全削除）
   - 削除されたタスク数を返す

2. **SayCoeiroinkクラス**
   - `clearSpeechQueue(taskIds?: number[])` - 拡張メソッドに対応

3. **MCPツール**
   - `queue_clear` ツールにtaskIds引数を追加
   - 削除結果の詳細表示

### ✅ テスト
- タスクID指定削除の各種パターン
- 後方互換性の確認
- エッジケース対応

## テスト結果
```
✓ SpeechQueue > clear > 特定のタスクIDのみ削除できること
✓ SpeechQueue > clear > 複数のタスクIDを同時に削除できること
✓ SpeechQueue > clear > 存在しないタスクIDを指定しても安全に動作すること
✓ SpeechQueue > clear > 空の配列を指定すると全削除と同じ動作をすること
```

全テスト383件パス

## 今後の拡張候補（Phase 3）
- 再生停止機能（AudioPlayer改修が必要）

refs #135

🤖 Generated with Claude Code