### PR TITLE
fix: リリースワークフローのバージョン決定ロジックを改善

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -63,6 +63,28 @@ jobs:
           # Apply changeset version
           npx changeset version
 
+          # Determine the highest version from all packages
+          HIGHEST_VERSION=""
+          for pkg in packages/*/package.json; do
+            if [ -f "$pkg" ]; then
+              PKG_VERSION=$(node -p "require('./$pkg').version")
+              if [ -z "$HIGHEST_VERSION" ] || [ "$(printf '%s\n' "$HIGHEST_VERSION" "$PKG_VERSION" | sort -V | tail -n1)" = "$PKG_VERSION" ]; then
+                HIGHEST_VERSION="$PKG_VERSION"
+              fi
+            fi
+          done
+
+          # Update root package.json with the highest version
+          if [ -n "$HIGHEST_VERSION" ]; then
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+              pkg.version = '$HIGHEST_VERSION';
+              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+            "
+            echo "Updated root package.json to version $HIGHEST_VERSION"
+          fi
+
           # Commit if there are changes
           if [ -n "$(git status --porcelain)" ]; then
             git add -A
@@ -75,8 +97,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Extract version from the most significant package (core)
-          VERSION=$(node -p "require('./packages/core/package.json').version")
+          # Extract version from root package.json (which now has the highest version)
+          VERSION=$(node -p "require('./package.json').version")
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
 
           # Check if PR already exists


### PR DESCRIPTION
## 🐛 問題

リリースPRのタイトルが「Release v1.1.1」となり、期待される「Release v1.2.0」にならない問題を修正します。

## 🔍 原因

1. **PRタイトルの決定**: coreパッケージのバージョン（1.1.1）を使用していた
2. **ルートpackage.json**: changesetで更新されていなかった

## ✅ 修正内容

### `.github/workflows/release-version.yml`の変更:

1. **ルートpackage.jsonの自動更新**:
   - 全パッケージから最も高いバージョンを検出
   - ルートpackage.jsonをそのバージョンに更新

2. **PRタイトルの改善**:
   - ルートpackage.jsonのバージョンを使用（最高バージョンが反映される）

## 📊 影響

- リリースPRのタイトルが正しいバージョン（v1.2.0）を表示
- ルートpackage.jsonが常に最新バージョンを反映
- 全体のバージョン管理が一元化される

## 🧪 テスト

現在のリリースPR（#152）を閉じて、新しいリリースプロセスを開始することで確認できます。