### PR TITLE
fix: リリースワークフローでブランチ名からバージョンを直接取得するよう修正

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -63,26 +63,21 @@ jobs:
           # Apply changeset version
           npx changeset version
 
-          # Determine the highest version from all packages
-          HIGHEST_VERSION=""
-          for pkg in packages/*/package.json; do
-            if [ -f "$pkg" ]; then
-              PKG_VERSION=$(node -p "require('./$pkg').version")
-              if [ -z "$HIGHEST_VERSION" ] || [ "$(printf '%s\n' "$HIGHEST_VERSION" "$PKG_VERSION" | sort -V | tail -n1)" = "$PKG_VERSION" ]; then
-                HIGHEST_VERSION="$PKG_VERSION"
-              fi
-            fi
-          done
+          # Extract version from branch name (release/x.x.x)
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          if [[ "$BRANCH_NAME" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
 
-          # Update root package.json with the highest version
-          if [ -n "$HIGHEST_VERSION" ]; then
+            # Update root package.json with the version from branch name
             node -e "
               const fs = require('fs');
               const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-              pkg.version = '$HIGHEST_VERSION';
+              pkg.version = '$VERSION';
               fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
             "
-            echo "Updated root package.json to version $HIGHEST_VERSION"
+            echo "Updated root package.json to version $VERSION (from branch name)"
+          else
+            echo "Warning: Could not extract version from branch name: $BRANCH_NAME"
           fi
 
           # Commit if there are changes


### PR DESCRIPTION
## 概要
リリースワークフローにおけるルートパッケージのバージョン決定ロジックを修正しました。

## 問題
- 現在の実装では、全パッケージの最大バージョンを計算してルートに設定していました
- この方式では、特定のパッケージのみ更新する場合に問題が発生
  - 例: CLI 1.2.1へのパッチリリース時、ルート 1.3.0が更新されない

## 解決方法
`release/x.x.x`ブランチ名から直接バージョンを抽出するよう変更しました。

### 変更前の動作
```bash
# 全パッケージから最大バージョンを計算
CLI: 1.2.1
Core: 1.3.0
Audio: 1.3.0
→ ルート: 1.3.0 (CLIの1.2.1は無視される)
```

### 変更後の動作
```bash
# ブランチ名から直接取得
release/1.3.1
→ ルート: 1.3.1 (ブランチ名に従う)
```

## メリット
- リリースブランチ名が真実の源となり、意図が明確
- パッケージ個別のパッチリリースでも正しく動作
- バージョン決定ロジックがシンプルで理解しやすい

## テスト方法
1. `release/x.x.x`ブランチを作成
2. changesetを含むコミットをプッシュ
3. GitHub Actionsが自動的にバージョンを更新
4. ルートpackage.jsonがブランチ名のバージョンに更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)