### PR TITLE
fix: changesetからrootパッケージの記述を削除

### DIFF
--- a/.changeset/changeset-2a5f63.md
+++ b/.changeset/changeset-2a5f63.md
@@ -1,11 +1,8 @@
 ---
-"coeiro-operator": patch
 "@coeiro-operator/mcp-debug": minor
 ---
 
 MCP初期化プロトコルの改善とベストプラクティスガイド追加
-
-## @coeiro-operator/mcp-debug
 
 ### 新機能
 - tools/listリクエストのサポート追加
@@ -28,8 +25,3 @@ MCP初期化プロトコルの改善とベストプラクティスガイド追�
 - MCP Protocol Best Practices Guide 新規作成
 - 初期化プロトコルの正しい理解を解説
 - よくある誤解と解決方法を網羅
-
-## coeiro-operator (root)
-
-### ドキュメント
-- mcp-debugの改善に伴うドキュメント整備


### PR DESCRIPTION
## 修正内容

changesetファイル内の `coeiro-operator` (rootパッケージ) の記述を削除しました。

rootパッケージは `private: true` のため、changesetで管理できません。
バージョンは release-version.yml ワークフローがブランチ名から自動的に設定します。

## 変更後

```yaml
---
"@coeiro-operator/mcp-debug": minor
---
```

他の既存changesetと同様、サブパッケージのみを指定する形になりました。