### PR TITLE
refactor: 句読点ポーズ設定の簡素化

### DIFF
--- a/.changeset/simplify-punctuation-pause-settings.md
+++ b/.changeset/simplify-punctuation-pause-settings.md
@@ -1,0 +1,32 @@
+---
+"@coeiro-operator/core": patch
+"@coeiro-operator/audio": patch
+---
+
+句読点ポーズ設定を簡素化し一貫性を向上
+
+- `PunctuationPauseSettings`から`enabled`フラグを削除（各値を0にすることで無効化可能）
+- `PunctuationPauseSettings`から`baseMorasPerSecond`を削除（VoiceConfigから取得するため不要）
+- `pauseMoras`ネストを削除し、フラットな構造に変更
+- 型定義、実装コード、テスト、ドキュメントを一貫した仕様に統一
+
+**変更前:**
+```typescript
+punctuationPause: {
+  enabled: true,
+  pauseMoras: { period: 2.0 },
+  baseMorasPerSecond: 7.5
+}
+```
+
+**変更後:**
+```typescript
+punctuationPause: {
+  period: 2.0,
+  exclamation: 1.5,
+  question: 1.8,
+  comma: 0.8
+}
+```
+
+この変更により、よりシンプルで直感的な設定が可能になりました。

--- a/packages/audio/docs/improvement-proposal-punctuation-pause.md
+++ b/packages/audio/docs/improvement-proposal-punctuation-pause.md
@@ -41,44 +41,40 @@ const DEFAULT_PUNCTUATION_MORAS = {
   comma: 0.8,       // 、の後（0.8モーラ分＝「っ」より短い）
 };
 
+/**
+ * PunctuationPauseSettings: 句読点ポーズ設定
+ *
+ * ポーズの長さをモーラ数で指定します。
+ * 日本語は等間隔のモーラリズムなので、話速が変わっても自然な比率を保てます。
+ * 各値を0に設定することでそのポーズを無効化できます。
+ *
+ * 実際のポーズ時間は VoiceConfig.styleMorasPerSecond から計算された話速に基づいて決定されます。
+ */
 interface PunctuationPauseSettings {
-  enabled: boolean;
-
-  // ポーズの長さをモーラ数で指定
-  // 日本語は等間隔のモーラリズムなので、話速が変わっても自然な比率を保てる
-  pauseMoras?: {
-    period?: number;      // 。の後（モーラ数）
-    exclamation?: number; // ！の後（モーラ数）
-    question?: number;    // ？の後（モーラ数）
-    comma?: number;       // 、の後（モーラ数）
-  };
-
-  // デフォルトの基準話速（省略時は7.5モーラ/秒）
-  // 標準的な日本語話速: 7-8モーラ/秒
-  // 速い: 10モーラ/秒以上
-  // 遅い: 5モーラ/秒以下
-  baseMorasPerSecond?: number;
+  period?: number;      // 。の後（モーラ数、0で無効）
+  exclamation?: number; // ！の後（モーラ数、0で無効）
+  question?: number;    // ？の後（モーラ数、0で無効）
+  comma?: number;       // 、の後（モーラ数、0で無効）
 }
 
-// VoiceConfigに話速情報を追加（実装案）
+// VoiceConfigに話速情報を追加（実装済み）
 interface VoiceConfig {
   speaker: Speaker;
   selectedStyleId: number;
-  // キャラクター固有の基準話速（実測値）
-  baseMorasPerSecond?: number;
+  // スタイル毎の基準話速（実測値）
+  styleMorasPerSecond?: Record<number, number>;
 }
 ```
 
 実装方法：
 ```typescript
-// audio-player.ts に追加
+// audio-stream-controller.ts に実装済み
 private calculatePauseDuration(
   punctuation: string,
-  speedScale: number,  // 話速の倍率（1.0 = 標準話速）
-  voiceConfig: VoiceConfig,  // 現在の音声設定
-  settings: PunctuationPauseSettings
+  actualMorasPerSecond: number,  // VoiceConfigから計算された実際の話速
+  settings?: PunctuationPauseSettings
 ): number {
-  if (!settings.enabled) return 0;
+  if (!settings) return 0;
 
   const punctuationMap = {
     '。': 'period',
@@ -93,49 +89,50 @@ private calculatePauseDuration(
   // デフォルト値と設定値をマージ
   const pauseMoras = {
     ...DEFAULT_PUNCTUATION_MORAS,
-    ...settings.pauseMoras,
+    ...settings,
   };
-
-  // 基準話速を取得（優先順位: VoiceConfig > 設定 > デフォルト）
-  const baseMorasPerSecond =
-    voiceConfig.baseMorasPerSecond ||
-    settings.baseMorasPerSecond ||
-    7.5;
-
-  logger.debug(
-    `${voiceConfig.speaker.speakerName}の基準話速: ${baseMorasPerSecond}モーラ/秒`
-  );
-
-  // speedScale = rate / 200 (sayコマンド互換)
-  // rate=200のとき speedScale=1.0（各キャラクターの基準速度）
-  // rate=100のとき speedScale=0.5（半分の速度）
-  // rate=400のとき speedScale=2.0（2倍の速度）
-  const morasPerSecond = baseMorasPerSecond * speedScale;
 
   // ポーズ時間を計算（モーラ数 → ミリ秒）
   const pauseInMoras = pauseMoras[type];
-  const pauseDuration = (pauseInMoras / morasPerSecond) * 1000;
+
+  // ポーズ値が0以下なら無効
+  if (pauseInMoras <= 0) return 0;
+
+  const pauseDuration = (pauseInMoras / actualMorasPerSecond) * 1000;
+
+  logger.debug(
+    `句読点「${punctuation}」のポーズ: ${pauseInMoras}モーラ → ${Math.round(pauseDuration)}ms`
+  );
 
   return Math.round(pauseDuration);
 }
 
-private async insertPauseBetweenChunks(
-  chunk: Chunk,
-  nextChunk: Chunk | null,
-  speedScale: number,
-  settings: PunctuationPauseSettings
-): Promise<ArrayBuffer | null> {
-  if (!settings.enabled || !nextChunk) return null;
+// synthesizeStream内で句読点ポーズを挿入（実装済み）
+// 句読点ポーズの挿入（最後のチャンク以外）
+if (this.options.punctuationPause && chunkIndex < chunks.length - 1) {
+  const lastPunctuation = this.getLastPunctuation(result.data.chunk.text);
+  if (lastPunctuation) {
+    const pauseDuration = this.calculatePauseDuration(
+      lastPunctuation,
+      actualMorasPerSecond,
+      this.options.punctuationPause
+    );
 
-  const lastChar = chunk.text[chunk.text.length - 1];
-  const pauseDuration = this.calculatePauseDuration(lastChar, speedScale, settings);
+    if (pauseDuration > 0) {
+      // 無音WAVデータを生成
+      const silenceWAV = this.generateSilenceWAV(pauseDuration);
 
-  if (pauseDuration > 0) {
-    logger.debug(`句読点「${lastChar}」の後に${pauseDuration}msのポーズを挿入`);
-    return this.generateSilence(pauseDuration);
+      // ポーズ用のAudioResultを作成
+      const pauseResult: AudioResult = {
+        chunk: { text: '', index: result.data.chunk.index + 0.5, isFirst: false, isLast: false, overlap: 0 },
+        audioBuffer: silenceWAV,
+        latency: 0,
+      };
+
+      logger.debug(`句読点「${lastPunctuation}」の後に${pauseDuration}msのポーズを挿入`);
+      yield pauseResult;
+    }
   }
-
-  return null;
 }
 ```
 
@@ -160,67 +157,71 @@ COEIROINKのAPIに`pauseLength`や`pauseScale`のようなパラメータが存�
 ## 設定例
 
 ```typescript
-// デフォルト設定（pauseMorasを省略すると自動でデフォルト値を使用）
+// デフォルト設定（全フィールド省略で自動的にデフォルト値を使用）
 const audioConfig = {
-  punctuationPause: {
-    enabled: true,
-    // pauseMoras省略 = デフォルト値を使用
-  }
+  punctuationPause: {}
 };
 
 // 部分的にカスタマイズ（指定しない項目はデフォルト値）
 const audioConfig = {
   punctuationPause: {
-    enabled: true,
-    pauseMoras: {
-      period: 3.0,      // 句点だけ長めに（3モーラ分）
-      // exclamation, question, commaはデフォルト値
-    }
+    period: 3.0,  // 句点だけ長めに（3モーラ分）
+    // exclamation, question, commaはデフォルト値
   }
 };
 
 // より長めのポーズが欲しい場合（ゆったりした会話）
 const audioConfig = {
   punctuationPause: {
-    enabled: true,
-    pauseMoras: {
-      period: 3.5,      // 3.5モーラ分
-      exclamation: 2.5, // 2.5モーラ分
-      question: 3.0,    // 3.0モーラ分
-      comma: 1.2,       // 1.2モーラ分
-    }
+    period: 3.5,      // 3.5モーラ分
+    exclamation: 2.5, // 2.5モーラ分
+    question: 3.0,    // 3.0モーラ分
+    comma: 1.2,       // 1.2モーラ分
   }
 };
 
 // 短めでテンポ良く（きびきびした会話）
 const audioConfig = {
   punctuationPause: {
-    enabled: true,
-    pauseMoras: {
-      period: 1.2,      // 1.2モーラ分
-      exclamation: 0.8, // 0.8モーラ分
-      question: 1.0,    // 1.0モーラ分
-      comma: 0.4,       // 0.4モーラ分
-    }
+    period: 1.2,      // 1.2モーラ分
+    exclamation: 0.8, // 0.8モーラ分
+    question: 1.0,    // 1.0モーラ分
+    comma: 0.4,       // 0.4モーラ分
   }
 };
 
-// VoiceConfigに実測値を設定する例
+// 完全に無効化（全ての句読点ポーズをオフ）
+const audioConfig = {
+  punctuationPause: {
+    period: 0,
+    exclamation: 0,
+    question: 0,
+    comma: 0,
+  }
+};
+
+// VoiceConfigに実測値を設定する例（スタイル毎の話速）
 const voiceConfigs: Record<string, VoiceConfig> = {
   tsukuyomi: {
     speaker: tsukuyomiSpeaker,
     selectedStyleId: 0,
-    baseMorasPerSecond: 7.2,  // 実測値
+    styleMorasPerSecond: {
+      0: 7.2,  // ノーマルスタイルの実測値
+    },
   },
   dia: {
     speaker: diaSpeaker,
     selectedStyleId: 3,
-    baseMorasPerSecond: 7.8,  // 実測値
+    styleMorasPerSecond: {
+      3: 7.8,  // のーまるスタイルの実測値
+    },
   },
   himehime: {
     speaker: himehimeSpeaker,
     selectedStyleId: 21,
-    baseMorasPerSecond: 8.1,  // 実測値
+    styleMorasPerSecond: {
+      21: 8.1,  // ノーマルスタイルの実測値
+    },
   },
 };
 
@@ -288,23 +289,9 @@ async function measureAndUpdateVoiceConfig(
 // - rate=100 → speedScale=0.5 → 3.6モーラ/秒
 // - rate=300 → speedScale=1.5 → 10.8モーラ/秒
 
-// BaseCharacterConfigの拡張（実装案）
-export interface BaseCharacterConfig {
-  // ... 既存フィールド ...
-  baseMorasPerSecond?: number;  // キャラクター固有の基準話速
-}
-
-// 起動時にconfig.jsonから読み込み、VoiceConfigに反映
-function createVoiceConfig(
-  speaker: Speaker,
-  characterConfig: CharacterConfig
-): VoiceConfig {
-  return {
-    speaker,
-    selectedStyleId: speaker.styles[0].styleId,
-    baseMorasPerSecond: characterConfig.baseMorasPerSecond
-  };
-}
+// VoiceConfigへの反映（実装済み）
+// styleMorasPerSecondはconfig.jsonから読み込まれ、
+// VoiceResolverによって自動的にVoiceConfigに設定されます
 ```
 
 ## 期待される効果

--- a/packages/audio/src/punctuation-pause.test.ts
+++ b/packages/audio/src/punctuation-pause.test.ts
@@ -96,10 +96,7 @@ describe('句読点ポーズ機能', () => {
       };
 
       const settings: PunctuationPauseSettings = {
-        enabled: true,
-        pauseMoras: {
-          period: 2.0, // 2モーラ分のポーズ
-        },
+        period: 2.0, // 2モーラ分のポーズ
       };
 
       // 8.0モーラ/秒の場合: 2.0モーラ ÷ 8.0モーラ/秒 = 0.25秒 = 250ms
@@ -135,10 +132,7 @@ describe('句読点ポーズ機能', () => {
       };
 
       const settings: PunctuationPauseSettings = {
-        enabled: true,
-        pauseMoras: {
-          comma: 1.0, // 1モーラ分のポーズ
-        },
+        comma: 1.0, // 1モーラ分のポーズ
       };
 
       // 7.5モーラ/秒の場合: 1.0モーラ ÷ 7.5モーラ/秒 = 0.133...秒 = 133ms
@@ -166,10 +160,7 @@ describe('句読点ポーズ機能', () => {
       };
 
       const settings: PunctuationPauseSettings = {
-        enabled: true,
-        pauseMoras: {
-          question: 2.5, // 2.5モーラ分のポーズ
-        },
+        question: 2.5, // 2.5モーラ分のポーズ
       };
 
       // 9.0モーラ/秒の場合: 2.5モーラ ÷ 9.0モーラ/秒 = 0.278秒 = 278ms
@@ -197,10 +188,7 @@ describe('句読点ポーズ機能', () => {
       };
 
       const settings: PunctuationPauseSettings = {
-        enabled: true,
-        pauseMoras: {
-          exclamation: 2.0, // 2モーラ分のポーズ
-        },
+        exclamation: 2.0, // 2モーラ分のポーズ
       };
 
       // 4.0モーラ/秒の場合: 2.0モーラ ÷ 4.0モーラ/秒 = 0.5秒 = 500ms
@@ -225,11 +213,10 @@ describe('句読点ポーズ機能', () => {
       };
 
       const settings: PunctuationPauseSettings = {
-        enabled: true,
-        // pauseMorasが未定義
+        // 全フィールド未定義
       };
 
-      // デフォルト値: 話速=7.5モーラ/秒, period=2.0
+      // デフォルト値: 話速=7.5モーラ/秒, period=2.0（DEFAULT_PUNCTUATION_MORAS）
       // 2.0モーラ ÷ 7.5モーラ/秒 = 0.267秒 = 267ms
       const duration = (controller as any).calculatePauseDuration(
         '。',
@@ -239,7 +226,7 @@ describe('句読点ポーズ機能', () => {
       expect(duration).toBe(267);
     });
 
-    it('設定が無効な場合は0を返す', () => {
+    it('ポーズ値が0の場合は0を返す', () => {
       const voiceConfig: VoiceConfig = {
         speakerId: 'test',
         speaker: {
@@ -251,7 +238,7 @@ describe('句読点ポーズ機能', () => {
       };
 
       const settings: PunctuationPauseSettings = {
-        enabled: false, // 無効化
+        period: 0, // 無効化
       };
 
       const duration = (controller as any).calculatePauseDuration(
@@ -283,10 +270,7 @@ describe('句読点ポーズ機能', () => {
 
     it('スタイル毎の話速設定を使用する', () => {
       const settings: PunctuationPauseSettings = {
-        enabled: true,
-        pauseMoras: {
-          period: 2.0,
-        },
+        period: 2.0,
       };
 
       // ねむねむスタイル（遅い）: 2.0モーラ ÷ 4.8モーラ/秒 = 0.417秒 = 417ms
@@ -315,10 +299,7 @@ describe('句読点ポーズ機能', () => {
       };
 
       const settings: PunctuationPauseSettings = {
-        enabled: true,
-        pauseMoras: {
-          period: 2.0,
-        },
+        period: 2.0,
       };
 
       const chunks = await (controller as any).processSpeechWithPunctuation(
@@ -345,13 +326,10 @@ describe('句読点ポーズ機能', () => {
       };
 
       const settings: PunctuationPauseSettings = {
-        enabled: true,
-        pauseMoras: {
-          period: 2.0,
-          exclamation: 2.0,
-          question: 2.5,
-          comma: 1.0,
-        },
+        period: 2.0,
+        exclamation: 2.0,
+        question: 2.5,
+        comma: 1.0,
       };
 
       const chunks = await (controller as any).processSpeechWithPunctuation(
@@ -400,7 +378,10 @@ describe('句読点ポーズ機能', () => {
       };
 
       const settings: PunctuationPauseSettings = {
-        enabled: false,
+        period: 0,
+        exclamation: 0,
+        question: 0,
+        comma: 0,
       };
 
       const chunks = await (controller as any).processSpeechWithPunctuation(

--- a/packages/audio/src/types.ts
+++ b/packages/audio/src/types.ts
@@ -50,18 +50,18 @@ export interface VoiceConfig {
 /**
  * PunctuationPauseSettings: 句読点ポーズ設定
  * 日本語発話に特化したモーラベースのポーズ制御
+ *
+ * ポーズの長さをモーラ数で指定します。
+ * 日本語は等間隔のモーラリズムなので、話速が変わっても自然な比率を保てます。
+ * 各値を0に設定することでそのポーズを無効化できます。
+ *
+ * 実際のポーズ時間は VoiceConfig.styleMorasPerSecond から計算された話速に基づいて決定されます。
  */
 export interface PunctuationPauseSettings {
-  enabled: boolean; // ポーズ機能の有効/無効
-
-  // ポーズの長さをモーラ数で指定
-  // 日本語は等間隔のモーラリズムなので、話速が変わっても自然な比率を保てる
-  pauseMoras?: {
-    period?: number;      // 。の後（モーラ数）
-    exclamation?: number; // ！の後（モーラ数）
-    question?: number;    // ？の後（モーラ数）
-    comma?: number;       // 、の後（モーラ数）
-  };
+  period?: number;      // 。の後（モーラ数、0で無効）
+  exclamation?: number; // ！の後（モーラ数、0で無効）
+  question?: number;    // ？の後（モーラ数、0で無効）
+  comma?: number;       // 、の後（モーラ数、0で無効）
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,14 +44,10 @@ export interface AudioConfig {
     pauseUntilFirstComplete?: boolean;
   };
   punctuationPause?: {
-    enabled?: boolean;
-    pauseMoras?: {
-      period?: number;      // 。の後（モーラ数）
-      exclamation?: number; // ！の後（モーラ数）
-      question?: number;    // ？の後（モーラ数）
-      comma?: number;       // 、の後（モーラ数）
-    };
-    baseMorasPerSecond?: number; // デフォルトの基準話速（モーラ/秒）
+    period?: number;      // 。の後（モーラ数、0で無効）
+    exclamation?: number; // ！の後（モーラ数、0で無効）
+    question?: number;    // ？の後（モーラ数、0で無効）
+    comma?: number;       // 、の後（モーラ数、0で無効）
   };
 }
 


### PR DESCRIPTION
## Summary

句読点ポーズ設定（`PunctuationPauseSettings`）の構造を簡素化し、一貫性を向上させました。

## 変更内容

### 型定義の簡素化

- ❌ **削除**: `enabled`フラグ（冗長、各値を0にすることで無効化可能）
- ❌ **削除**: `baseMorasPerSecond`（未使用、VoiceConfigから取得すべき）
- ❌ **削除**: `pauseMoras`ネスト（不要な階層）
- ✅ **変更**: 各句読点のポーズ値を直接フィールドとして定義

### Before

```typescript
punctuationPause: {
  enabled: true,
  pauseMoras: {
    period: 2.0,
    exclamation: 1.5,
    question: 1.8,
    comma: 0.8
  },
  baseMorasPerSecond: 7.5
}
```

### After

```typescript
punctuationPause: {
  period: 2.0,
  exclamation: 1.5,
  question: 1.8,
  comma: 0.8
}
```

## 修正したファイル

- `packages/core/src/types.ts` - AudioConfig型定義の簡素化
- `packages/audio/src/types.ts` - PunctuationPauseSettings型定義の簡素化
- `packages/audio/src/audio-stream-controller.ts` - enabledチェック削除、設定アクセス方法変更
- `packages/audio/src/punctuation-pause.test.ts` - テストケース更新
- `packages/audio/docs/improvement-proposal-punctuation-pause.md` - ドキュメント更新

## デフォルト動作

- `punctuationPause`未定義 → ポーズなし（0ms）
- `punctuationPause: {}` → DEFAULT_PUNCTUATION_MORAS を使用
- `punctuationPause: { period: 0 }` → 句点のポーズのみ無効

## Test plan

- [x] 型チェック成功（`pnpm run type-check`）
- [x] 既存テストの更新完了
- [x] ドキュメント更新完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)