### PR TITLE
feat: wait_for_task_completionにイベントベースのremainingQueueLengthオプションを追加

### DIFF
--- a/.changeset/mcp-wait-queue-length.md
+++ b/.changeset/mcp-wait-queue-length.md
@@ -1,0 +1,33 @@
+---
+"@coeiro-operator/mcp": patch
+"@coeiro-operator/audio": patch
+---
+
+wait_for_task_completionにremainingQueueLengthオプションを追加（イベントベース実装）
+
+`wait_for_task_completion`ツールに、キューが指定数になったときに待ちを解除する`remainingQueueLength`オプションを追加しました。
+
+**使用例:**
+```typescript
+// キューが1個になったら解除
+wait_for_task_completion({ remainingQueueLength: 1 })
+
+// すべてのタスクが完了するまで待機（既存の動作）
+wait_for_task_completion({ remainingQueueLength: 0 })
+wait_for_task_completion()
+```
+
+**実装内容:**
+- `remainingQueueLength`パラメータを追加（デフォルト: 0）
+- 0の場合は既存の動作（全タスク完了まで待機）
+- **イベントベース実装**: ポーリングを避け、TaskQueueのイベント(`taskCompleted`, `queueEmpty`)を使用
+- TaskQueueにEventEmitterを継承させ、`waitForQueueLength()`メソッドを追加
+- SayCoeiroinkに`waitForQueueLength()`を公開
+- タイムアウト・エラーメッセージも残数に応じて適切に表示
+
+**技術詳細:**
+- TaskQueueに`taskCompleted`イベント（タスク完了時）と`queueEmpty`イベント（キュー空時）を追加
+- `waitForQueueLength(targetLength)`メソッドでイベントリスナーを登録し、条件達成で解決
+- ポーリング不要で効率的な待機を実現
+
+refs #182

--- a/packages/audio/src/index.ts
+++ b/packages/audio/src/index.ts
@@ -128,6 +128,25 @@ export class SayCoeiroink {
     }
   }
 
+  /**
+   * キューが指定された長さになるまで待機（イベントベース）
+   * @param targetLength 待機解除するキュー長（デフォルト0 = 完全に空になるまで待機）
+   * エラーが発生した場合は最初のエラーを投げる
+   */
+  async waitForQueueLength(targetLength: number = 0): Promise<void> {
+    if (!this.speechQueue) {
+      throw new Error('SpeechQueue is not initialized. Call initialize() first.');
+    }
+    const result = await this.speechQueue.waitForQueueLength(targetLength);
+
+    // エラーがある場合は最初のエラーを投げる
+    if (result.errors.length > 0) {
+      const firstError = result.errors[0];
+      logger.warn(`音声処理中に${result.errors.length}件のエラーが発生しました`);
+      throw firstError.error;
+    }
+  }
+
   // ========================================================================
   // ユーティリティメソッド
   // ========================================================================


### PR DESCRIPTION
## Summary

Issue #182の実装を**ポーリングからイベントベース**に変更しました。

### 主な変更

#### 1. TaskQueueにEventEmitter機能を追加
- `EventEmitter`を継承
- `taskCompleted`イベント: タスク完了時に発行
- `queueEmpty`イベント: キュー空時に発行

#### 2. waitForQueueLength()メソッドを実装
- イベントリスナーで条件達成を検知
- ポーリング不要で効率的な待機を実現
- targetLength引数で柔軟な待機条件を指定可能

#### 3. SayCoeiroinkに公開
- `waitForQueueLength(targetLength)`メソッドを追加
- エラーハンドリングも統一

#### 4. MCPサーバーの実装を書き換え
- `wait_for_task_completion`ツールをイベントベースに変更
- 100ms間隔のポーリングを廃止

### 技術的な利点

✅ **CPU効率**: ポーリングを廃止し、イベント駆動に
✅ **レスポンス速度**: イベント発火で即座に反応
✅ **リソース使用**: より効率的なシステムリソース管理

### 使用例

```typescript
// キューが1個になったら解除
wait_for_task_completion({ remainingQueueLength: 1 })

// すべてのタスクが完了するまで待機（既存の動作）
wait_for_task_completion({ remainingQueueLength: 0 })
wait_for_task_completion()
```

## Test plan

- [x] 型チェック成功
- [ ] 実際の動作確認（手動テスト推奨）

🤖 Generated with [Claude Code](https://claude.com/claude-code)