### PR TITLE
docs: MCPサーバーのnpx起動方法をREADMEに明記

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,15 @@ npm install -g @coeiro-operator/mcp
 claude mcp add coeiro-operator
 
 # または、npxで直接実行する場合は手動設定
-# claude_desktop_config.jsonに追加
+# claude_desktop_config.jsonに以下を追加：
+# {
+#   "mcpServers": {
+#     "coeiro-operator": {
+#       "command": "npx",
+#       "args": ["-y", "--package", "@coeiro-operator/mcp", "coeiro-operator"]
+#     }
+#   }
+# }
 
 # AI Agent用の設定（Claude Code利用時）
 # 音声対話が必要な場合、prompts/recipes/operator-mode.mdを

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -25,13 +25,13 @@ claude mcp add coeiro-operator
   "mcpServers": {
     "coeiro-operator": {
       "command": "npx",
-      "args": ["-y", "@coeiro-operator/mcp"]
+      "args": ["-y", "--package", "@coeiro-operator/mcp", "coeiro-operator"]
     }
   }
 }
 ```
 
-※ `npx @coeiro-operator/mcp`は内部的に`coeiro-operator`コマンドを実行します
+※ `npx -y --package "@coeiro-operator/mcp" coeiro-operator`でパッケージを自動インストールして`coeiro-operator`コマンドを実行します
 
 ## 提供される機能
 


### PR DESCRIPTION
*🤖 by Claude Code*

## Summary

MCPサーバーが`npx -y @coeiro-operator/mcp`で起動しない問題の解決方法をREADMEに明記しました。

## 問題

`npx -y @coeiro-operator/mcp`でMCPサーバーを起動しようとすると、以下のエラーで失敗します：

```
sh: coeiro-operator: command not found
```

**原因:**
パッケージのbinフィールドが`{"coeiro-operator": "./dist/server.js"}`と定義されているため、npxでパッケージ名を直接指定しても`coeiro-operator`コマンドが見つかりません。

## 解決方法

正しいnpx起動方法をREADMEに明記：

```bash
npx -y --package "@coeiro-operator/mcp" coeiro-operator
```

Claude CodeのMCP設定：

```json
{
  "mcpServers": {
    "coeiro-operator": {
      "command": "npx",
      "args": ["-y", "--package", "@coeiro-operator/mcp", "coeiro-operator"]
    }
  }
}
```

## 変更内容

- **packages/mcp/README.md**: 方法2のnpx起動設定を修正
- **README.md**: ルートREADMEにnpx設定例を追加
- `-y`オプションを追加して確認プロンプトなしで自動インストール

## 参考

- `npx --package <pkg> <cmd>`: パッケージをインストールして指定コマンドを実行
- `-y`: 確認なしで自動インストール
- binのキーが`coeiro-operator`なので、このコマンド名を明示的に指定する必要がある

## Test plan

- [x] README記述を確認
- [x] コミットメッセージを確認