### PR TITLE
feat: npm Trusted Publishingに対応

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -55,14 +55,15 @@ jobs:
       - name: Build packages
         run: pnpm build:all
 
-      - name: Publish to npm
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@latest
+
+      - name: Publish to npm (with Trusted Publishing)
         run: |
           # Versions and changelogs are already updated in the release branch
           # Use pnpm to publish packages in dependency order (prevents race conditions)
-          pnpm publish -r --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Use --provenance for trusted publishing (requires id-token: write permission)
+          pnpm publish -r --no-git-checks --provenance --access public
 
       - name: Push tags only
         run: |


### PR DESCRIPTION
*🤖 by Claude Code*

## 概要

npm Trusted Publishing（Provenance）に対応し、セキュアなパッケージ公開を実現します。

## 変更内容

### release-branch.yml
- npmを最新版に更新するステップを追加
- `pnpm publish`に`--provenance`フラグを追加
- `--access public`フラグを追加
- NPM_TOKEN環境変数を削除（GitHub OIDCトークンを使用）

## Trusted Publishingとは

- GitHubのOIDCトークンを使用してnpmに認証
- パッケージの出所（provenance）を証明
- より安全なパッケージ公開を実現
- NPM_TOKENの管理が不要

## 参考

search-docsの実装を参考にしています。

## 注意事項

- npmパッケージ側でTrusted Publisherの設定が必要です
- 既存のNPM_TOKENは互換性のため残していますが、使用されません

🤖 Generated with [Claude Code](https://claude.com/claude-code)