### PR TITLE
operator_status/assignの出力改善: スタイル情報追加・簡潔化

### DIFF
--- a/.changeset/operator-output-improvement.md
+++ b/.changeset/operator-output-improvement.md
@@ -1,0 +1,5 @@
+---
+"@coeiro-operator/mcp": patch
+---
+
+operator_statusにキャラクタ設定・スタイル一覧を表示。operator_assignのスタイル一覧を簡潔化し、スタイル変更方法の案内を追加。

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -188,7 +188,7 @@ logger.info('Available characters for MCP tools:', { available: availableCharact
 if (isGroupEnabled('operator')) {
   registerOperatorAssignTool(server, sayCoeiroink, operatorManager, characterInfoService, terminalBackground, availableCharacters.available);
   registerOperatorReleaseTool(server, operatorManager, terminalBackground);
-  registerOperatorStatusTool(server, operatorManager);
+  registerOperatorStatusTool(server, operatorManager, characterInfoService);
   registerOperatorAvailableTool(server, operatorManager);
   registerOperatorStylesTool(server, operatorManager, characterInfoService);
 } else {

--- a/packages/mcp/src/tools/operator.test.ts
+++ b/packages/mcp/src/tools/operator.test.ts
@@ -264,7 +264,7 @@ describe('Operator Tools', () => {
 
   describe('registerOperatorStatusTool', () => {
     test('ツールが正しく登録されること', () => {
-      registerOperatorStatusTool(mockServer, mockOperatorManager);
+      registerOperatorStatusTool(mockServer, mockOperatorManager, mockCharacterInfoService);
 
       expect(mockServer.registerTool).toHaveBeenCalledWith(
         'operator_status',
@@ -274,10 +274,32 @@ describe('Operator Tools', () => {
     });
 
     test('ステータスが取得できること', async () => {
-      registerOperatorStatusTool(mockServer, mockOperatorManager);
+      registerOperatorStatusTool(mockServer, mockOperatorManager, mockCharacterInfoService);
 
       vi.mocked(mockOperatorManager.showCurrentOperator).mockResolvedValue({
+        characterId: 'tsukuyomi',
+        characterName: 'つくよみちゃん',
+        currentStyle: {
+          styleId: '0',
+          styleName: 'れいせい',
+          personality: '冷静で丁寧',
+          speakingStyle: '敬語',
+        },
         message: '現在のオペレータ: つくよみちゃん',
+      });
+
+      vi.mocked(mockCharacterInfoService.getCharacterInfo).mockResolvedValue({
+        characterId: 'tsukuyomi',
+        speakerId: '0',
+        speakerName: 'つくよみちゃん',
+        personality: '冷静で丁寧',
+        speakingStyle: '敬語',
+        defaultStyleId: 0,
+        greeting: 'こんにちは',
+        farewell: 'さようなら',
+        styles: {
+          0: { styleName: 'れいせい', morasPerSecond: 8.61, personality: '冷静で丁寧', speakingStyle: '敬語' },
+        },
       });
 
       const tool = registeredTools.get('operator_status');

--- a/packages/mcp/src/tools/operator.ts
+++ b/packages/mcp/src/tools/operator.ts
@@ -18,6 +18,7 @@ import {
   assignOperator,
   extractStyleInfo,
   formatAssignmentResult,
+  formatStyleList,
   formatStylesResult,
   getTargetCharacter,
 } from '../utils.js';
@@ -188,7 +189,8 @@ export function registerOperatorReleaseTool(
  */
 export function registerOperatorStatusTool(
   server: McpServer,
-  operatorManager: OperatorManager
+  operatorManager: OperatorManager,
+  characterInfoService: CharacterInfoService
 ): void {
   server.registerTool(
     'operator_status',
@@ -200,13 +202,28 @@ export function registerOperatorStatusTool(
       try {
         const status = await operatorManager.showCurrentOperator();
 
+        if (!status.characterId) {
+          return {
+            content: [{ type: 'text', text: status.message }],
+          };
+        }
+
+        let resultText = `現在のオペレータ: ${status.characterName || status.characterId} (${status.characterId})\n`;
+
+        if (status.currentStyle) {
+          resultText += `現在のスタイル: ${status.currentStyle.styleName} (${status.currentStyle.styleId})\n`;
+          resultText += `   性格: ${status.currentStyle.personality}\n`;
+          resultText += `   話し方: ${status.currentStyle.speakingStyle}\n`;
+        }
+
+        const character = await characterInfoService.getCharacterInfo(status.characterId);
+        if (character) {
+          const availableStyles = extractStyleInfo(character);
+          resultText += formatStyleList(availableStyles, status.currentStyle?.styleId);
+        }
+
         return {
-          content: [
-            {
-              type: 'text',
-              text: status.message,
-            },
-          ],
+          content: [{ type: 'text', text: resultText }],
         };
       } catch (error) {
         throw new Error(`オペレータ状況確認エラー: ${(error as Error).message}`);

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -52,38 +52,34 @@ export function extractStyleInfo(character: Character): StyleInfo[] {
 }
 
 /**
+ * スタイル一覧を簡潔にフォーマット（operator_status / operator_assign 共通）
+ */
+export function formatStyleList(availableStyles: StyleInfo[], currentStyleId?: string): string {
+  if (availableStyles.length <= 1) return '';
+
+  let text = `\n利用可能なスタイル:\n`;
+  availableStyles.forEach(style => {
+    const isCurrent = style.id === currentStyleId;
+    const marker = isCurrent ? '→ ' : '  ';
+    text += `${marker}${style.id}: ${style.name}\n`;
+  });
+  text += `\n💡 スタイル変更: operator_assign の styleName に名前またはIDを指定（例: styleName="おしとやか" または styleName="5"）\n`;
+  return text;
+}
+
+/**
  * アサイン結果をフォーマット
  */
 export function formatAssignmentResult(assignResult: AssignResult, availableStyles: StyleInfo[]): string {
   let resultText = `${assignResult.characterName} (${assignResult.characterId}) をアサインしました。\n\n`;
 
   if (assignResult.currentStyle) {
-    resultText += `📍 現在のスタイル: ${assignResult.currentStyle.styleName}\n`;
+    resultText += `📍 現在のスタイル: ${assignResult.currentStyle.styleName} (${assignResult.currentStyle.styleId})\n`;
     resultText += `   性格: ${assignResult.currentStyle.personality}\n`;
     resultText += `   話し方: ${assignResult.currentStyle.speakingStyle}\n`;
-    // 現在のスタイルの話速を取得
-    const currentStyleInfo = availableStyles.find(s => s.id === assignResult.currentStyle?.styleId);
-    if (currentStyleInfo?.morasPerSecond) {
-      resultText += `   基準話速: ${currentStyleInfo.morasPerSecond} モーラ/秒\n`;
-    }
-    resultText += '\n';
   }
 
-  if (availableStyles.length > 1) {
-    resultText += `🎭 利用可能なスタイル（切り替え可能）:\n`;
-    availableStyles.forEach(style => {
-      const isCurrent = style.id === assignResult.currentStyle?.styleId;
-      const marker = isCurrent ? '→ ' : '  ';
-      resultText += `${marker}${style.id}: ${style.name}\n`;
-      resultText += `    性格: ${style.personality}\n`;
-      resultText += `    話し方: ${style.speakingStyle}\n`;
-      if (style.morasPerSecond) {
-        resultText += `    基準話速: ${style.morasPerSecond} モーラ/秒\n`;
-      }
-    });
-  } else {
-    resultText += `ℹ️  このキャラクターは1つのスタイルのみ利用可能です。\n`;
-  }
+  resultText += formatStyleList(availableStyles, assignResult.currentStyle?.styleId);
 
   if (assignResult.greeting) {
     resultText += `\n💬 "${assignResult.greeting}"\n`;


### PR DESCRIPTION
*🤖 by Claude Code*

## Summary
- `operator_status` の出力にキャラクタの性格・話し方・利用可能スタイル一覧を追加
  - LLMセッションとは独立してオペレータが永続するため、セッション開始時にoperator_statusで確認した際にアシスタントが適切な振る舞いを判断できるようにする
- `operator_assign` のスタイル一覧を簡潔化（各スタイルの性格・話し方・話速の全展開を削除）
- スタイル変更方法の案内を追加（名前またはIDで指定可能）

## Test plan
- [ ] `operator_status` でオペレータ割り当て済み時にスタイル情報が表示されること
- [ ] `operator_status` で未割り当て時は従来通りの表示であること
- [ ] `operator_assign` の出力が簡潔になっていること
- [ ] ビルドが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)